### PR TITLE
Fix import script for email signins

### DIFF
--- a/scripts/import-supabase-auth.ts
+++ b/scripts/import-supabase-auth.ts
@@ -34,7 +34,7 @@ const firebaseAuthExportString = fs.readFileSync("firebase_auth_export.json", "u
 let firebaseAuthExport: FirebaseAuthExport;
 try {
   const firebaseAuthExportObject = JSON.parse(firebaseAuthExportString);
-  if (!isFirebaseAuthExport(firebaseAuthExportString)) {
+  if (!isFirebaseAuthExport(firebaseAuthExportObject)) {
     throw new Error("Failed type guards.");
   }
 
@@ -43,6 +43,7 @@ try {
   console.error(
     'Invalid "firebase_auth_export.json", run "yarn export" before running this script.'
   );
+  console.error(error)
   process.exit(1);
 }
 console.info(`${firebaseAuthExport.users.length} Firebase Auth users found in the export.`);
@@ -97,8 +98,8 @@ console.info(`${firebaseAuthExport.users.length} Firebase Auth users found in th
         created_at: new Date(Number(user.createdAt)),
         updated_at: new Date(Number(user.createdAt)),
         last_sign_in_at: new Date(Number(user.lastSignedInAt)),
-        raw_app_meta_data: { provider: provider.providerId.replace(".com", "") },
-        raw_user_meta_data: { full_name: user.displayName, avatar_url: provider.photoUrl },
+        raw_app_meta_data: provider ? { provider: provider.providerId.replace(".com", "") } : {},
+        raw_user_meta_data: { full_name: user.displayName, avatar_url: provider ? provider.photoUrl : '' },
       };
 
       return { newAuthUserData };


### PR DESCRIPTION
# Issue

The import script (`scripts/import-supabase-auth.ts`) is completely broken because when it tries to validate the auth export it checks the JSON string *not* the parsed JSON.

Also there are instances where the user does not have any provider info (eg. when signed up by email).

# Solution

Pass the correct variable to the validator.

Check if provider info exists before using the data inside of it.

# Other changes

Dumped the error to the console because it is super helpful for the dev.

# Testing

- [x] works for my Firebase -> Supabase app with users signed up with email and Google